### PR TITLE
[Actomaton] Add `Reducer.map(id:)` & `Reducer.map(queue:)`

### DIFF
--- a/Sources/Actomaton/Reducer.swift
+++ b/Sources/Actomaton/Reducer.swift
@@ -97,4 +97,28 @@ public struct Reducer<Action, State, Environment>: Sendable
             )
         }
     }
+
+    // MARK: - Functor
+
+    /// Changes `EffectID`.
+    public func map<ID>(id f: @escaping @Sendable (EffectID?) -> ID?) -> Reducer
+        where ID: EffectIDProtocol
+    {
+        .init { action, state, environment in
+            let effect = self.run(action, &state, environment)
+                .map(id: f)
+            return effect
+        }
+    }
+
+    /// Changes `EffectQueue`.
+    public func map<Queue>(queue f: @escaping @Sendable (EffectQueue?) -> Queue?) -> Reducer
+        where Queue: EffectQueueProtocol
+    {
+        .init { action, state, environment in
+            let effect = self.run(action, &state, environment)
+                .map(queue: f)
+            return effect
+        }
+    }
 }


### PR DESCRIPTION
This PR adds **`Reducer.map(id:)` & `Reducer.map(queue:)`** just as `Effect` has.

This mappings becomes useful when EffectIDs and EffectQueues are defined differently in multiple modules,
but end user wants to treat them as the same one.

In such scenario:

```swift
// From Module 1
let reducer1 = Reducer { ... } // using EffectQueue1

// From Module2
let reducer2 = Reducer { ... } // using EffectQueue2

// App using Module1 & Module2
let combinedReducer = Reducer.combine(reducer1, reducer2)
    .map(queue: { queue in
        if queue is EffectQueue1 || queue is EffectQueue2 {
            return AppEffectQueue() // unifying into the same EffectQueue
        }
        return queue
    })
```