### PR TITLE
[Test] Fix `EffectQueueDelayTests.test_DelayedNewest2EffectQueue` for Swift 5.7 slow cancellation propagation

### DIFF
--- a/Tests/ActomatonTests/EffectQueueDelayTests.swift
+++ b/Tests/ActomatonTests/EffectQueueDelayTests.swift
@@ -24,6 +24,20 @@ final class EffectQueueDelayTests: XCTestCase
 
                         print("Start: \(id), Task.isCancelled = \(Task.isCancelled)")
 
+                        // Swift 5.7 requirement:
+                        // Add short delay before checking `Task.isCancelled` since Swift 5.7's cancellation propagation
+                        // seems to become slower than Swift 5.6 and needs to wait for actual `Task.isCancelled` check.
+                        // Note that this tweak is only needed for testing purpose,
+                        // and won't be necessary for production code.
+                        do {
+                            try await Task.sleep(nanoseconds: 1_000_000)
+                        }
+                        catch {
+                            // Ignore cancellation handling during `Task.sleep`.
+                        }
+
+                        print("Start (recheck): \(id), Task.isCancelled = \(Task.isCancelled)")
+
                         // NOTE:
                         // Because of delayed effect cancellation may occur by `EffectQueue`,
                         // `Task.isCancelled` may already be `true` at here.


### PR DESCRIPTION
This PR fixes https://twitter.com/inamiy/status/1534013394386558976 
where Xcode 14 Beta 1 (Swift 5.7) fails the async test that was once working in Xcode 13.4 (Swift 5.6),
possibly due to Swift Concurrency change that `Task` cancellation propagation becomes slower than before for some reason.

To alleviate this issue, this PR adds a short delay before `Task.isCancelled` check so that `Task.isCancelled` will be safely observed.