### PR TITLE
[Test] Fix DeinitTests

### DIFF
--- a/Tests/ActomatonTests/DeinitTests.swift
+++ b/Tests/ActomatonTests/DeinitTests.swift
@@ -39,26 +39,19 @@ final class DeinitTests: XCTestCase
         actomaton = nil
         XCTAssertNil(weakActomaton, "`weakActomaton` should also become `nil`.")
 
-        // Check results.
-        do {
-            let results = await resultsCollector.results
-            XCTAssertEqual(
-                results, [],
-                "Effect cancellation needs next run-loop to run, so there is no `results` yet."
-            )
-        }
-
         // Wait until deinit fully completes.
         try? await task?.value
 
         // Check results.
-        do {
-            let results = await resultsCollector.results
-            XCTAssertEqual(
-                results, ["Effect cancelled", "DeinitChecker deinit"],
-                "Running effect should be cancelled, and `DeinitChecker` should deinit"
-            )
-        }
+        //
+        // NOTE:
+        // Arrival timing of 2 results are almost simultaneous thus isn't guaranteed in order,
+        // so will use `Set` here.
+        let results = await resultsCollector.results
+        XCTAssertEqual(
+            Set(results), ["Effect cancelled", "DeinitChecker deinit"],
+            "Running effect should be cancelled, and `DeinitChecker` should deinit."
+        )
     }
 }
 


### PR DESCRIPTION
Fixes:
- #58 

#58 caused following test failures due to:

1. `deinit` timing is not guaranteed after setting `nil`
2. Order of "effect cancellation" and "deinit checker" is not guaranteed

![](https://user-images.githubusercontent.com/138476/173558109-3738bae8-6552-466f-880f-6add9ed38569.png)

This PR fixes them by: 1. removing precondition test, 2. using `Set` to ignore event's arrival order.
