### PR TITLE
[Store] Fix: Add `func send` task capture `[weak self]`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -69,6 +69,16 @@ let package = Package(
             ]
         ),
         .testTarget(
+            name: "ActomatonStoreTests",
+            dependencies: ["ActomatonStore", "TestFixtures"],
+            swiftSettings: [
+                .unsafeFlags([
+                    "-Xfrontend", "-warn-concurrency",
+                    "-Xfrontend", "-enable-actor-data-race-checks",
+                ])
+            ]
+        ),
+        .testTarget(
             name: "ReadMeTests",
             dependencies: ["ActomatonStore", "ActomatonDebugging"],
             swiftSettings: [

--- a/Sources/ActomatonStore/Store.swift
+++ b/Sources/ActomatonStore/Store.swift
@@ -98,8 +98,8 @@ open class Store<Action, State, Environment>: ObservableObject
 
         // Send `action` to `actomaton` asynchronously,
         // which also calls `reducer` inside its actor to update state and also runs effects.
-        return Task(priority: priority) {
-            let task = await self.actomaton.send(.action(action), priority: priority, tracksFeedbacks: tracksFeedbacks)
+        return Task(priority: priority) { [weak self] in
+            let task = await self?.actomaton.send(.action(action), priority: priority, tracksFeedbacks: tracksFeedbacks)
             try await task?.value
         }
     }

--- a/Tests/ActomatonStoreTests/DeinitTests.swift
+++ b/Tests/ActomatonStoreTests/DeinitTests.swift
@@ -1,16 +1,16 @@
 import XCTest
 @testable import Actomaton
-
-import Combine
+@testable import ActomatonStore
 
 /// Tests for `Actomaton.deinit` to run successfully with cancelling running tasks.
+@MainActor
 final class DeinitTests: XCTestCase
 {
     func test_deinit() async throws
     {
         let resultsCollector = ResultsCollector<String>()
 
-        var actomaton: Actomaton? = Actomaton<Action, State>(
+        var actomaton: Store? = Store<Action, State, Environment>(
             state: State(),
             reducer: Reducer { [resultsCollector] action, state, _ in
                 switch action {
@@ -32,7 +32,7 @@ final class DeinitTests: XCTestCase
 
         weak var weakActomaton = actomaton
 
-        let task = await actomaton?.send(.run)
+        let task = actomaton?.send(.run)
         try await tick(1)
 
         // Deinit `actomaton`.

--- a/Tests/ActomatonStoreTests/_exported.swift
+++ b/Tests/ActomatonStoreTests/_exported.swift
@@ -1,0 +1,1 @@
+@_exported import TestFixtures


### PR DESCRIPTION
This PR, Fix tests `ActomatonStore.deinitTests` to pass from failure.

<img width="1167" alt="スクリーンショット 2022-06-15 9 51 56" src="https://user-images.githubusercontent.com/26223064/173714837-5a24b587-bc29-4a86-b544-67ce7cadc481.png">

it's ActomatonStore fixed to add `weak self` capture because to when do deinit then not deallocation Store instance.
