### PR TITLE
fix access level for viewdidload of hostingviewcontroller

### DIFF
--- a/Sources/ActomatonStore/UIKit-Support/HostingViewController.swift
+++ b/Sources/ActomatonStore/UIKit-Support/HostingViewController.swift
@@ -78,7 +78,7 @@ open class HostingViewController<Action, State, Environment, V: SwiftUI.View>: U
         fatalError("init(coder:) has not been implemented")
     }
 
-    public override func viewDidLoad()
+    open override func viewDidLoad()
     {
         super.viewDidLoad()
 


### PR DESCRIPTION
open classなHostingViewControllerの中でviewDidLoadがpublicで宣言されており、overrideができないためopenに修正
<img width="582" alt="スクリーンショット 2022-06-24 10 42 19" src="https://user-images.githubusercontent.com/8661733/175445475-80a6fedc-8c7a-47e5-b9fa-e7e560a22e31.png">
