### PR TITLE
Introduce ActomatonUI

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,6 +10,9 @@ let package = Package(
             name: "Actomaton",
             targets: ["Actomaton", "ActomatonDebugging"]),
         .library(
+            name: "ActomatonUI",
+            targets: ["ActomatonUI", "ActomatonDebugging"]),
+        .library(
             name: "ActomatonStore",
             targets: ["ActomatonStore", "ActomatonDebugging"])
     ],
@@ -31,8 +34,19 @@ let package = Package(
         .target(
             name: "ActomatonStore",
             dependencies: [
-                "Actomaton",
-                .product(name: "CasePaths", package: "swift-case-paths")
+                "Actomaton"
+            ],
+            swiftSettings: [
+                .unsafeFlags([
+                    "-Xfrontend", "-warn-concurrency",
+                    "-Xfrontend", "-enable-actor-data-race-checks",
+                ])
+            ]
+        ),
+        .target(
+            name: "ActomatonUI",
+            dependencies: [
+                "Actomaton"
             ],
             swiftSettings: [
                 .unsafeFlags([

--- a/Sources/ActomatonUI/Extensions/Combine+Helper.swift
+++ b/Sources/ActomatonUI/Extensions/Combine+Helper.swift
@@ -1,0 +1,52 @@
+import Combine
+
+extension Publisher
+{
+    /// `Publisher` to `AsyncThrowingStream`.
+    public func toAsyncThrowingStream() -> AsyncThrowingStream<Output, Swift.Error>
+    {
+        AsyncThrowingStream<Output, Swift.Error>(Output.self) { continuation in
+            let cancellable = self
+                .sink(
+                    receiveCompletion: { completion in
+                        switch completion {
+                        case .finished:
+                            continuation.finish()
+                        case let .failure(error):
+                            continuation.yield(with: .failure(error))
+                        }
+                    },
+                    receiveValue: { output in
+                        continuation.yield(output)
+                    }
+                )
+
+            continuation.onTermination = { @Sendable _ in
+                withExtendedLifetime(cancellable, {})
+            }
+        }
+    }
+
+    /// `Publisher` to `AsyncStream`.
+    public func toAsyncStream() -> AsyncStream<Output> where Failure == Never
+    {
+        AsyncStream(Output.self) { continuation in
+            let cancellable = self
+                .sink(
+                    receiveCompletion: { completion in
+                        switch completion {
+                        case .finished:
+                            continuation.finish()
+                        }
+                    },
+                    receiveValue: { output in
+                        continuation.yield(output)
+                    }
+                )
+
+            continuation.onTermination = { @Sendable _ in
+                withExtendedLifetime(cancellable, {})
+            }
+        }
+    }
+}

--- a/Sources/ActomatonUI/Extensions/MutableCollection+Helper.swift
+++ b/Sources/ActomatonUI/Extensions/MutableCollection+Helper.swift
@@ -1,0 +1,19 @@
+extension MutableCollection
+{
+    /// Safe get / set element for `MutableCollection`.
+    ///
+    /// - Note: When working with SwiftUI, safe array access is often needed to avoid `ContiguousArrayBuffer` index out of range error.
+    ///   https://stackoverflow.com/questions/59295206/how-do-you-use-enumerated-with-foreach-in-swiftui/63145650
+    public subscript (safe index: Index) -> Iterator.Element?
+    {
+        get {
+            self.startIndex <= index && index < self.endIndex
+                ? self[index]
+                : nil
+        }
+        set {
+            guard let newValue = newValue, self.startIndex <= index && index < self.endIndex else { return }
+            self[index] = newValue
+        }
+    }
+}

--- a/Sources/ActomatonUI/Internal/DebugLog.swift
+++ b/Sources/ActomatonUI/Internal/DebugLog.swift
@@ -1,0 +1,11 @@
+// MARK: - DebugLog
+
+enum Debug
+{
+    static func print(_ msg: Any)
+    {
+#if DEBUG
+//        Swift.print("===>", msg)
+#endif
+    }
+}

--- a/Sources/ActomatonUI/Store/CurrentValuePublisher.swift
+++ b/Sources/ActomatonUI/Store/CurrentValuePublisher.swift
@@ -1,0 +1,56 @@
+import Combine
+
+/// Read-only `CurrentValueSubject` with sharing original value on `map`.
+@propertyWrapper
+public struct CurrentValuePublisher<Value>
+{
+    private let _value: () -> Value
+    private let publisher: AnyPublisher<Value, Never>
+
+    private init(value: @escaping () -> Value, publisher: AnyPublisher<Value, Never>)
+    {
+        self._value = value
+        self.publisher = publisher
+    }
+
+    public init(_ currentValueSubject: CurrentValueSubject<Value, Never>)
+    {
+        self.init(
+            value: { currentValueSubject.value },
+            publisher: currentValueSubject.eraseToAnyPublisher()
+        )
+    }
+
+    public var wrappedValue: Value
+    {
+        nonmutating get {
+            self._value()
+        }
+    }
+
+    public var projectedValue: AnyPublisher<Value, Never>
+    {
+        self.publisher
+    }
+
+    /// Functor-map with sharing original value.
+    public func map<Value2>(_ f: @escaping (Value) -> Value2) -> CurrentValuePublisher<Value2>
+    {
+        .init(
+            value: { f(self._value()) },
+            publisher: self.publisher.map(f).eraseToAnyPublisher()
+        )
+    }
+}
+
+extension CurrentValuePublisher: Publisher
+{
+    public func receive<S>(subscriber: S)
+        where S: Subscriber, S.Failure == Never, S.Input == Value
+    {
+        self.publisher.subscribe(subscriber)
+    }
+
+    public typealias Output = Value
+    public typealias Failure = Never
+}

--- a/Sources/ActomatonUI/Store/Internal/BindableAction.swift
+++ b/Sources/ActomatonUI/Store/Internal/BindableAction.swift
@@ -1,0 +1,17 @@
+/// `action` as indirect messaging, or `state` that can directly replace `actomaton.state` via SwiftUI 2-way binding.
+internal enum BindableAction<Action, State>: Sendable
+    where Action: Sendable, State: Sendable
+{
+    case action(Action)
+    case state(State)
+
+    func map<SubAction>(action f: (Action) -> SubAction) -> BindableAction<SubAction, State>
+    {
+        switch self {
+        case let .action(action):
+            return .action(f(action))
+        case let .state(state):
+            return .state(state)
+        }
+    }
+}

--- a/Sources/ActomatonUI/Store/Internal/StoreCore.swift
+++ b/Sources/ActomatonUI/Store/Internal/StoreCore.swift
@@ -1,0 +1,115 @@
+import Combine
+
+/// `MainActomaton` wrapper that handles both `Action` as indirect messaging
+/// and `State` that can directly replace `actomaton.state` via SwiftUI 2-way binding.
+@MainActor
+internal final class StoreCore<Action, State, Environment>
+    where Action: Sendable, State: Sendable, Environment: Sendable
+{
+    private let actomaton: MainActomaton<BindableAction<Action, State>, State>
+    private let reducer: Reducer<Action, State, Environment>
+
+    private let _state: CurrentValueSubject<State, Never>
+
+    internal let environment: Environment
+
+    internal var cancellables: Set<AnyCancellable> = []
+
+    /// Initializer with `environment`.
+    internal init(
+        state initialState: State,
+        reducer: Reducer<Action, State, Environment>,
+        environment: Environment
+    )
+    {
+        self._state = CurrentValueSubject(initialState)
+        self.reducer = reducer
+        self.environment = environment
+
+        self.actomaton = MainActomaton(
+            state: initialState,
+            reducer: lift(reducer: Reducer { action, state, environment in
+                reducer.run(action, &state, environment)
+            }),
+            environment: environment
+        )
+
+        self.actomaton.$state
+            .sink(receiveValue: { [weak self] state in
+                self?.updateState(state)
+            })
+            .store(in: &cancellables)
+
+        // Comment-Out: Using `for await` causes SwiftUI animation not working correctly.
+//        self.task = Task { [weak self] in
+//            guard let stream = self?.actomaton.$state.toAsyncStream() else { return }
+//
+//            for await newState in stream {
+//                self?.updateState(newState)
+//            }
+//        }
+    }
+
+    deinit
+    {
+        Debug.print("[deinit] StoreCore \(String(format: "%p", ObjectIdentifier(self).hashValue))")
+    }
+
+    internal var state: CurrentValuePublisher<State>
+    {
+        .init(self._state)
+    }
+
+    /// Sends either `action` or `state`.
+    ///
+    /// - Parameters:
+    ///   - priority:
+    ///     Priority of the task. If `nil`, the priority will come from `Task.currentPriority`.
+    ///   - tracksFeedbacks:
+    ///     If `true`, returned `Task` will also track its feedback effects that are triggered by next actions,
+    ///     so that their wait-for-all and cancellations are possible.
+    ///     Default is `false`.
+    ///
+    /// - Returns:
+    ///   Unified task that can handle (wait for or cancel) all combined effects triggered by `action` in `Reducer`.
+    @discardableResult
+    internal func send(
+        _ action: BindableAction<Action, State>,
+        priority: TaskPriority? = nil,
+        tracksFeedbacks: Bool = false
+    ) -> Task<(), Error>?
+    {
+        switch action {
+        case let .action(action):
+            return self.actomaton.send(.action(action), priority: priority, tracksFeedbacks: tracksFeedbacks)
+
+        case let .state(state):
+            return self.actomaton.send(.state(state), priority: priority, tracksFeedbacks: tracksFeedbacks)
+        }
+    }
+
+    private func updateState(_ newState: State)
+    {
+        self._state.value = newState
+    }
+}
+
+// MARK: - Private
+
+/// Lifts from `Reducer`'s `Action` to `Store.BindableAction`.
+private func lift<Action, State, Environment>(
+    reducer: Reducer<Action, State, Environment>
+) -> Reducer<BindableAction<Action, State>, State, Environment>
+{
+    .init { action, state, environment in
+        switch action {
+        case let .action(innerAction):
+            let effect = reducer.run(innerAction, &state, environment)
+            return effect.map { BindableAction<Action, State>.action($0) }
+
+        case let .state(newState):
+            state = newState
+            return .empty
+        }
+    }
+}

--- a/Sources/ActomatonUI/Store/Store.swift
+++ b/Sources/ActomatonUI/Store/Store.swift
@@ -1,0 +1,375 @@
+/// `MainActomaton`-erased wrapper which can ``map(state:)-1wcms`` into sub-store.
+///
+/// - Important: ``Store`` is NOT `ObservableObject` thus its state can't be observed by SwiftUI views.
+///
+/// To make it observable in SwiftUI, use ``WithViewStore`` (SwiftUI View) to create ``ViewStore`` which is `ObservableObject`.
+/// Note that ``Store/map(state:)-1wcms`` can narrow down ``Store``'s scope before passing to ``WithViewStore``
+/// so that only the subset of state changes can be observed by SwiftUI, allowing optimized rendering.
+///
+/// ```swift
+/// struct ContentView: View {
+///     let store: Store<Action, State, Environment>
+///     ...
+///     var body: some View {
+///         WithViewStore(store) { viewStore in
+///             Text("Hello, \(viewStore.state.username)") // NOTE: Can shorten to `viewStore.username`.
+///         }
+///         // NOTE:
+///         // This impl is OK, but it observes `store`'s entire state, which is not optimal.
+///         // To only observe `state.username` change (for optimization whenever needed),
+///         // narrow down the scope by calling `WithViewStore(store.map(state: \.username))` instead.
+///     }
+/// }
+/// ```
+///
+/// For UIKit views, use `$state` publisher to observe state change.
+/// To narrow down the scope and reduce duplicated partial-state update,
+/// use Combine's `map`, `compactMap`, and `removeDuplicates`.
+///
+/// ```swift
+/// let store: Store<State, Action, Environment>
+/// ...
+/// func viewDidLoad() {
+///     super.viewDidLoad()
+///
+///     // Receive partial state update.
+///     // (Use `removeDuplicates` for handling actual changes)
+///     self.store.$state
+///         .map { $0.username }
+///         .removeDuplicates()
+///         .sink { [weak self] in
+///             self?.label.text = $0
+///         }
+///         .store(in: &self.cancellables)
+/// }
+/// ```
+@MainActor
+public class Store<Action, State, Environment>
+    where Action: Sendable, State: Sendable, Environment: Sendable
+{
+    @CurrentValuePublisher
+    public var state: State
+
+    /// Public `Environment` that can be passed to `SwiftUI.View`.
+    ///
+    /// For example, `AVPlayer` may be needed in both `Reducer` and `AVKit.VideoPlayer`.
+    public let environment: Environment
+
+    private let _send: @MainActor (BindableAction<Action, State>, TaskPriority?, _ tracksFeedbacks: Bool) -> Task<(), Error>?
+
+    /// Initializer with `environment`.
+    public convenience init(
+        state initialState: State,
+        reducer: Reducer<Action, State, Environment>,
+        environment: Environment
+    )
+    {
+        let core = StoreCore<Action, State, Environment>(
+            state: initialState,
+            reducer: reducer,
+            environment: environment
+        )
+
+        self.init(
+            state: core.state,
+            environment: environment,
+            send: { core.send($0, priority: $1, tracksFeedbacks: $2) }
+        )
+    }
+
+    /// Initializer without `environment`.
+    public convenience init(
+        state initialState: State,
+        reducer: Reducer<Action, State, Void>
+    ) where Environment == Void
+    {
+        self.init(
+            state: initialState,
+            reducer: reducer,
+            environment: ()
+        )
+    }
+
+    /// Designated initializer with receiving `send` from single-source-of-truth `Store`.
+    internal init(
+        state: CurrentValuePublisher<State>,
+        environment: Environment,
+        send: @escaping @MainActor (BindableAction<Action, State>, TaskPriority?, _ tracksFeedbacks: Bool) -> Task<(), Error>?
+    )
+    {
+        self._state = state
+        self.environment = environment
+        self._send = send
+    }
+
+    /// Sends `action` to `Store`.
+    ///
+    /// - Parameters:
+    ///   - priority:
+    ///     Priority of the task. If `nil`, the priority will come from `Task.currentPriority`.
+    ///   - tracksFeedbacks:
+    ///     If `true`, returned `Task` will also track its feedback effects that are triggered by next actions,
+    ///     so that their wait-for-all and cancellations are possible.
+    ///     Default is `false`.
+    ///
+    /// - Returns:
+    ///   Unified task that can handle (wait for or cancel) all combined effects triggered by `action` in `Reducer`.
+    @discardableResult
+    public func send(
+        _ action: Action,
+        priority: TaskPriority? = nil,
+        tracksFeedbacks: Bool = false
+    ) -> Task<(), Error>?
+    {
+        self._send(.action(action), priority: priority, tracksFeedbacks: tracksFeedbacks)
+    }
+
+    /// Sends either `action` or `state`.
+    @discardableResult
+    internal func _send(
+        _ action: BindableAction<Action, State>,
+        priority: TaskPriority? = nil,
+        tracksFeedbacks: Bool = false
+    ) -> Task<(), Error>?
+    {
+        self._send(action, priority, tracksFeedbacks)
+    }
+
+    internal var currentValuePublisher: CurrentValuePublisher<State>
+    {
+        self._state
+    }
+}
+
+// MARK: - To ViewStore
+
+extension Store
+{
+    /// Creates `ViewStore` (SwiftUI `Binding`-builder).
+    public func viewStore(
+        areStatesEqual: @escaping (State, State) -> Bool
+    ) -> ViewStore<Action, State>
+    {
+        .init(
+            state: self._state,
+            send: { self._send($0, priority: $1, tracksFeedbacks: $2) },
+            areStatesEqual: areStatesEqual
+        )
+    }
+}
+
+extension Store where State: Equatable
+{
+    /// Creates `ViewStore` (SwiftUI `Binding`-builder).
+    public var viewStore: ViewStore<Action, State>
+    {
+        self.viewStore(areStatesEqual: ==)
+    }
+}
+
+// MARK: - Functor (Sub-Store)
+
+extension Store
+{
+    /// Transforms `<Action, State>` to `<Action, SubState>`.
+    public func map<SubState>(
+        state keyPath: WritableKeyPath<State, SubState>
+    ) -> Store<Action, SubState, Environment>
+        where SubState: Sendable
+    {
+        self.map(
+            state: (
+                get: { $0[keyPath: keyPath] },
+                set: { $0[keyPath: keyPath] = $1 }
+            )
+        )
+    }
+
+    /// Transforms `<Action, [State]>` to `<Action, [SubState]>`.
+    public func map<State_, SubState>(
+        states keyPath: WritableKeyPath<State_, SubState>
+    ) -> Store<Action, [SubState], Environment>
+        where State == [State_], State_: Sendable, SubState: Sendable
+    {
+        self.map(
+            state: (
+                get: { $0.map { $0[keyPath: keyPath] } },
+                set: { states, substates in
+                    for (i, substate) in zip(states.indices, substates) {
+                        states[i][keyPath: keyPath] = substate
+                    }
+                }
+            )
+        )
+    }
+
+    /// Transforms `<Action, State>` to `<Action, SubState>`.
+    fileprivate func map<SubState>(
+        state lens: (get: (State) -> SubState, set: (inout State, SubState) -> Void)
+    ) -> Store<Action, SubState, Environment>
+        where SubState: Sendable
+    {
+        .init(
+            state: self._state.map(lens.get),
+            environment: self.environment,
+            send: { action, priority, tracksFeedback in
+                switch action {
+                case let .action(action):
+                    return self._send(.action(action), priority: priority, tracksFeedbacks: tracksFeedback)
+
+                case let .state(substate):
+                    var state = self.state
+                    lens.set(&state, substate)
+                    return self._send(.state(state), priority: priority, tracksFeedbacks: tracksFeedback)
+                }
+            }
+        )
+    }
+
+    /// Transforms `Action` to `SubAction`.
+    public func contramap<SubAction>(action f: @escaping (SubAction) -> Action)
+        -> Store<SubAction, State, Environment>
+        where SubAction: Sendable
+    {
+        .init(
+            state: self._state,
+            environment: self.environment,
+            send: { action, priority, tracksFeedback in
+                self._send(action.map(action: f), priority: priority, tracksFeedbacks: tracksFeedback)
+            }
+        )
+    }
+
+    /// Transforms `Environment` to `SubEnvironment`.
+    public func map<SubEnvironment>(
+        environment f: @escaping (Environment) -> SubEnvironment
+    ) -> Store<Action, State, SubEnvironment>
+        where SubEnvironment: Sendable
+    {
+        .init(
+            state: self._state,
+            environment: f(self.environment),
+            send: self._send
+        )
+    }
+}
+
+// MARK: - Other state transforms
+
+extension Store
+{
+    /// Transforms `<Action, State>` to `<Action, SubState>`
+    /// where `SubState` is derived from `get`-only computed property which is not mutable.
+    ///
+    /// This is a weaker form of ``Store/map(state:)`` (which receives `WritableKeyPath`).
+    ///
+    /// - Warning: Returned store can NOT create direct state binding, i.e. ``ViewStore/directBinding``,
+    ///   and always require ``ViewStore/stateBinding(get:onChange:)`` (indirect binding) instead.
+    public func indirectMap<SubState>(
+        state get: @escaping (State) -> SubState
+    ) -> Store<Action, SubState, Environment>
+        where SubState: Sendable
+    {
+        .init(
+            state: self._state.map(get),
+            environment: self.environment,
+            send: { action, priority, tracksFeedback in
+                switch action {
+                case let .action(action):
+                    return self._send(.action(action), priority: priority, tracksFeedbacks: tracksFeedback)
+
+                case .state:
+                    // `SubState` is immutable, so should not reach here.
+                    assertionFailure("indirectMap error: `SubState` is immutable, so should not reach here.")
+                    return nil
+                }
+            }
+        )
+    }
+
+    /// Transforms `Store<Action, State>` to `Store<Action, SubState?>` using `casePath`,
+    /// - Note: This method should be used when `State` is enum type.
+    public func caseMap<SubState>(
+        state casePath: CasePath<State, SubState>
+    ) -> Store<Action, SubState?, Environment>
+        where SubState: Sendable
+    {
+        .init(
+            state: self._state.map(casePath.extract),
+            environment: self.environment,
+            send: { action, priority, tracksFeedback in
+                switch action {
+                case let .action(action):
+                    return self._send(.action(action), priority: priority, tracksFeedbacks: tracksFeedback)
+
+                case let .state(substate):
+                    guard let substate = substate else { return nil }
+
+                    let state = casePath.embed(substate)
+                    return self._send(.state(state), priority: priority, tracksFeedbacks: tracksFeedback)
+                }
+            }
+        )
+    }
+
+    /// Transforms `Store<Action, State?, Environment>` to `Store<Action, State, Environment>?`.
+    ///
+    /// - Note: This method can often be used alongside ``caseMap(state:)``.
+    ///
+    /// ```swift
+    /// // Decompositioning `store` into Screen1's sub-store, etc.
+    /// if let currentStore = store
+    ///     .map(state: \State.currentScreen) // struct State { var currentScreen: ScreenState? }
+    ///     .optionalize()
+    /// {
+    ///     if let screen1Store = currentStore
+    ///         .caseMap(state: /Screen.screen1) // enum ScreenState { case screen1(Screen1State) }
+    ///         .optionalize()
+    ///     {
+    ///         Screen1View(store: screen1Store) // Show Screen1 if `currentScreen = .screen1`.
+    ///     }
+    ///     else if screen2Store = currentStore
+    ///         .caseMap(state: /Screen.screen1)
+    ///         .optionalize()
+    ///     {
+    ///         Screen2View(store: screen2Store) // Show Screen2 if `currentScreen = .screen2`.
+    ///     }
+    ///     else ...
+    /// }
+    /// ```
+    public func optionalize<State_>()
+        -> Store<Action, State_, Environment>?
+        where State == State_?
+    {
+        guard let state = self.state else { return nil }
+        return self.map(state: (get: { $0 ?? state }, set: { $0 = $1 }))
+    }
+}
+
+// MARK: - noState, noAction, noEnvironment
+
+extension Store
+{
+    /// Converts `State` to `Void` so that `SwiftUI.View` won't get re-rendered on uninterested state change
+    /// when observing ``Store``'s derived ``ViewStore``.
+    public var noState: Store<Action, Void, Environment>
+    {
+        self.map(state: (get: { _ in () }, set: { _, _ in }))
+    }
+
+    /// Converts `Action` to `Never`.
+    public var noAction: Store<Never, State, Environment>
+    {
+        self.contramap(action: absurd)
+    }
+
+    /// Converts `Environment` to `Void` so that `SwiftUI.View` doesn't need to know about `Environment`.
+    public var noEnvironment: Store<Action, State, Void>
+    {
+        self.map(environment: { _ in () })
+    }
+}
+
+// MARK: - Private
+
+private func absurd<A>(_ x: Never) -> A {}

--- a/Sources/ActomatonUI/Store/Store.swift
+++ b/Sources/ActomatonUI/Store/Store.swift
@@ -185,6 +185,24 @@ extension Store
         )
     }
 
+    /// Transforms `<Action, State?>` to `<Action, SubState?>`.
+    public func map<State_, SubState>(
+        optionalState keyPath: WritableKeyPath<State_, SubState>
+    ) -> Store<Action, SubState?, Environment>
+        where State == State_?, State_: Sendable, SubState: Sendable
+    {
+        self.map(
+            state: (
+                get: { $0.map { $0[keyPath: keyPath] } },
+                set: { state, substate in
+                    if let substate = substate {
+                        state?[keyPath: keyPath] = substate
+                    }
+                }
+            )
+        )
+    }
+
     /// Transforms `<Action, [State]>` to `<Action, [SubState]>`.
     public func map<State_, SubState>(
         states keyPath: WritableKeyPath<State_, SubState>

--- a/Sources/ActomatonUI/Store/Store.swift
+++ b/Sources/ActomatonUI/Store/Store.swift
@@ -282,7 +282,7 @@ extension Store
     /// This is a weaker form of ``Store/map(state:)`` (which receives `WritableKeyPath`).
     ///
     /// - Warning: Returned store can NOT create direct state binding, i.e. ``ViewStore/directBinding``,
-    ///   and always require ``ViewStore/stateBinding(get:onChange:)`` (indirect binding) instead.
+    ///   and always require ``ViewStore/binding(get:onChange:)`` (indirect binding) instead.
     public func indirectMap<SubState>(
         state get: @escaping (State) -> SubState
     ) -> Store<Action, SubState, Environment>
@@ -298,7 +298,7 @@ extension Store
 
                 case .state:
                     // `SubState` is immutable, so should not reach here.
-                    assertionFailure("indirectMap error: `SubState` is immutable, so should not reach here.")
+                    assertionFailure("Detected the calls of `ViewStore.directBinding` after `Store.indirectMap` which is illegal. Always use `ViewStore.binding(get:onChange:)` whenever using `indirectMap`. Otherwise, direct-binding will be discarded in Release build.")
                     return nil
                 }
             }

--- a/Sources/ActomatonUI/SwiftUI/Binding+Helper.swift
+++ b/Sources/ActomatonUI/SwiftUI/Binding+Helper.swift
@@ -1,0 +1,90 @@
+import SwiftUI
+import CasePaths
+
+// MARK: - Functor
+
+extension Binding
+{
+    /// Transforms `<Value>` to `<SubValue>` using `get` and `set`.
+    public func transform<SubValue>(
+        get: @escaping (Value) -> SubValue,
+        set: @escaping (Value, SubValue) -> Value
+    ) -> Binding<SubValue>
+    {
+        Binding<SubValue>(
+            get: { get(self.wrappedValue) },
+            set: { self.transaction($1).wrappedValue = set(self.wrappedValue, $0) }
+        )
+    }
+
+    /// Transforms `<Value>` to `<SubValue>` using `WritableKeyPath`.
+    ///
+    /// - Note:
+    ///   This is almost the same as `subscript(dynamicMember:)` provided by SwiftUI,
+    ///   but this implementation can avoid internal `SwiftUI.BindingOperations.ForceUnwrapping` failure crash.
+    public subscript<SubValue>(_ keyPath: WritableKeyPath<Value, SubValue>)
+        -> Binding<SubValue>
+    {
+        Binding<SubValue>(
+            get: { self.wrappedValue[keyPath: keyPath] },
+            set: { self.transaction($1).wrappedValue[keyPath: keyPath] = $0 }
+        )
+    }
+
+    /// Transforms `<Value>` to `<SubValue?>` using `CasePath`.
+    /// - Note: `Value` should be enum value.
+    public subscript<SubValue>(casePath casePath: CasePath<Value, SubValue>)
+        -> Binding<SubValue?>
+    {
+        Binding<SubValue?>(
+            get: {
+                casePath.extract(from: self.wrappedValue)
+            },
+            set: { value, transaction in
+                if let value = value {
+                    self.transaction(transaction).wrappedValue = casePath.embed(value)
+                }
+            }
+        )
+    }
+}
+
+// MARK: - Traversable
+
+extension Binding
+{
+    /// Moves `SubValue?`'s optional part outside of `Binding`.
+    ///
+    /// - Note:
+    ///   `traverse(\.self)` will be same as `Bind.init?` (failable initializer),
+    ///   which turns `Binding<Value?>` into `Binding<Value>?`.
+    public func traverse<SubValue>(_ keyPath: WritableKeyPath<Value, SubValue?>)
+        -> Binding<SubValue>?
+    {
+        guard let subValue = self.wrappedValue[keyPath: keyPath] else {
+            return nil
+        }
+
+        return Binding<SubValue>(
+            get: { subValue },
+            set: { self.transaction($1).wrappedValue[keyPath: keyPath] = $0 }
+        )
+    }
+}
+
+// MARK: - onSet Hook
+
+extension Binding
+{
+    /// Adds setter hook.
+    public func onSet(_ hook: @escaping (_ old: Value, _ new: Value) -> Void) -> Binding<Value>
+    {
+        self.transform(
+            get: { $0 },
+            set: { old, new in
+                hook(old, new)
+                return new
+            }
+        )
+    }
+}

--- a/Sources/ActomatonUI/SwiftUI/ForEach+Store.swift
+++ b/Sources/ActomatonUI/SwiftUI/ForEach+Store.swift
@@ -1,0 +1,78 @@
+import SwiftUI
+
+extension ForEach
+{
+    /// `ForEach` for `Store` where its state is a collection of child states identified by `id` keyPath.
+    /// - SeeAlso: Why `zip` is used: https://stackoverflow.com/a/63145650/666371
+    @MainActor
+    public init<C, Action, Environment, InnerContent>(
+        store: Store<Action, C, Environment>,
+        id: KeyPath<C.Element, ID>,
+        @ViewBuilder content: @escaping (Store<Action, C.Element, Environment>) -> InnerContent
+    ) where
+        Data == [Zip2Sequence<C.Indices, C>.Element],
+        InnerContent: View,
+        Content == InnerContent?,
+        C: MutableCollection & RandomAccessCollection & Sendable,
+        C.Index: Hashable & Sendable,
+        C.Element: Sendable,
+        Action: Sendable,
+        Environment: Sendable
+    {
+        let firstKeyPath = \Zip2Sequence<C.Indices, C>.Element.1
+
+        let state = store.state
+
+        self.init(
+            Array(zip(state.indices, state)),
+            id: firstKeyPath.appending(path: id)
+        ) { index, child in
+            // IMPORTANT:
+            // Safe array access is needed to avoid `ContiguousArrayBuffer` index out of range error.
+            // https://stackoverflow.com/questions/59295206/how-do-you-use-enumerated-with-foreach-in-swiftui/63145650
+            let substore = store.map(state: \.[safe: index]).optionalize()
+
+            if let substore = substore {
+                content(substore)
+            }
+        }
+    }
+
+    /// `ForEach` for `Store` where its state is a collection of child states identified by `Identifiable` protocol.
+    /// - SeeAlso: Why `zip` is used: https://stackoverflow.com/a/63145650/666371
+    @MainActor
+    public init<C, Action, Environment, InnerContent>(
+        store: Store<Action, C, Environment>,
+        @ViewBuilder content: @escaping (Store<Action, C.Element, Environment>) -> InnerContent
+    ) where
+        Data == [Zip2Sequence<C.Indices, C>.Element],
+        InnerContent: View,
+        Content == InnerContent?,
+        C: MutableCollection & RandomAccessCollection & Sendable,
+        C.Index: Hashable & Sendable,
+        C.Element: Identifiable & Sendable,
+        C.Element.ID == ID,
+        Action: Sendable,
+        Environment: Sendable
+    {
+        self.init(store: store, id: \.id, content: content)
+    }
+}
+
+// MARK: - Private
+
+extension MutableCollection
+{
+    fileprivate subscript (safe index: Index) -> Iterator.Element?
+    {
+        get {
+            self.startIndex <= index && index < self.endIndex
+                ? self[index]
+                : nil
+        }
+        set {
+            guard let newValue = newValue, self.startIndex <= index && index < self.endIndex else { return }
+            self[index] = newValue
+        }
+    }
+}

--- a/Sources/ActomatonUI/SwiftUI/ForEach+Store.swift
+++ b/Sources/ActomatonUI/SwiftUI/ForEach+Store.swift
@@ -58,21 +58,3 @@ extension ForEach
         self.init(store: store, id: \.id, content: content)
     }
 }
-
-// MARK: - Private
-
-extension MutableCollection
-{
-    fileprivate subscript (safe index: Index) -> Iterator.Element?
-    {
-        get {
-            self.startIndex <= index && index < self.endIndex
-                ? self[index]
-                : nil
-        }
-        set {
-            guard let newValue = newValue, self.startIndex <= index && index < self.endIndex else { return }
-            self[index] = newValue
-        }
-    }
-}

--- a/Sources/ActomatonUI/SwiftUI/ViewStore.swift
+++ b/Sources/ActomatonUI/SwiftUI/ViewStore.swift
@@ -1,0 +1,174 @@
+import Combine
+import SwiftUI
+
+/// ``Store``'s `ObservableObject` proxy type that can create direct (state-to-state) & indirect (state-to-action) `Binding`s.
+///
+/// 1. Indirectly mutate `state` by ``binding(get:onChange:)`` and providing action "onChange"
+/// 2. Directly mutate `state` by ``directBinding``
+///     - Updated state that passes through this `Binding` will NOT pass user-defined `Reducer`.
+///
+/// Since ``Store`` is not capable of observing its state in SwiftUI, ``ViewStore`` is needed to be attached to SwiftUI view instead, either by:
+///
+/// 1. Create via ``Store/viewStore`` and attach to `SwiftUI.View` by writing
+///   `@ObservedObject var viewStore: ViewStore<Action, State>`
+/// 2. Use ``WithViewStore``
+///
+/// For example:
+///
+/// ```swift
+/// struct ContentView: View {
+///     let store: Store<Action, State, Environment>
+///     ...
+///     var body: some View {
+///         WithViewStore(store) { viewStore in
+///             Text("Hello, \(viewStore.state.username)") // NOTE: Can shorten to `viewStore.username`.
+///         }
+///     }
+/// }
+/// ```
+///
+/// - Note: Ideally, minimal size of `ViewStore` should be owned by `SwiftUI.View` for optimized SwiftUI rendering.
+///   To optimize as so, use ``Store/map(state:)`` to narrow-down its scope before converting to `ViewStore`
+///   via ``WithViewStore`` or ``Store/viewStore``.
+@dynamicMemberLookup
+@MainActor
+public final class ViewStore<Action, State>: ObservableObject
+    where Action: Sendable, State: Sendable
+{
+    /// State to be rendered for `SwiftUI.View`.
+    @Published
+    public private(set) var state: State
+
+    private let _send: @MainActor (
+        BindableAction<Action, State>, TaskPriority?, _ tracksFeedbacks: Bool
+    ) -> Task<(), Error>?
+
+    private var cancellables: Set<AnyCancellable> = []
+
+    /// Designated initializer with receiving `send` from single-source-of-truth `Store`.
+    internal init(
+        state: CurrentValuePublisher<State>,
+        send: @escaping @MainActor (
+            BindableAction<Action, State>, TaskPriority?, _ tracksFeedbacks: Bool
+        ) -> Task<(), Error>?,
+        areStatesEqual: @escaping (State, State) -> Bool
+    )
+    {
+        self.state = state.wrappedValue
+        self._send = send
+
+        // Sync from `StoreCore` state (upstream) to `ViewStore` state (downstream).
+        state
+            .sink(receiveValue: { [weak self] state in
+                guard let oldState = self?.state else { return }
+
+                if !areStatesEqual(state, oldState) {
+                    self?.state = state
+                }
+            })
+            .store(in: &self.cancellables)
+    }
+
+    /// Gets sub-state through `@dynamicMemberLookup`.
+    public subscript<SubState>(
+        dynamicMember keyPath: KeyPath<State, SubState>
+    ) -> SubState
+    {
+        self.state[keyPath: keyPath]
+    }
+
+    /// Sends either `action` or `state`.
+    @discardableResult
+    internal func _send(
+        _ action: BindableAction<Action, State>,
+        priority: TaskPriority? = nil,
+        tracksFeedbacks: Bool = false
+    ) -> Task<(), Error>?
+    {
+        self._send(action, priority, tracksFeedbacks)
+    }
+}
+
+// MARK: - Indirect (state-to-action) binding
+
+extension ViewStore
+{
+    /// Indirect state-to-action conversion binding to create `Binding<State>`.
+    public func binding(
+        onChange: @escaping (State) -> Action?
+    ) -> Binding<State>
+    {
+        self.binding(get: { $0 }, onChange: onChange)
+    }
+
+    /// Indirect state-to-action conversion binding to create `Binding<SubState>`.
+    public func binding<SubState>(
+        get: @escaping (State) -> SubState,
+        onChange: @escaping (SubState) -> Action?
+    ) -> Binding<SubState>
+    {
+        Binding<SubState>(
+            get: {
+                get(self.state)
+            },
+            set: { value, transaction in
+                if let action = onChange(value) {
+                    // NOTE:
+                    // `withTransaction` will work correctly only when
+                    // `configuration.updatesStateImmediately` is `true`
+                    // which will update state immediately on `@MainActor`.
+                    _ = withTransaction(transaction) {
+                        self._send(.action(action))
+                    }
+                }
+            }
+        )
+    }
+
+    /// Creates indirect `Binding<Bool>` as SwiftUI presentation binding from optional `State`, and sends `Action` on dismissal.
+    public func isPresented<Wrapped>(onDismiss: @autoclosure @escaping () -> Action) -> Binding<Bool>
+        where State == Wrapped?
+    {
+        self.binding(
+            get: { $0 != nil },
+            onChange: { isPresented in
+                isPresented ? nil : onDismiss()
+            }
+        )
+    }
+
+    /// Creates indirect `Binding<Bool>` from `State` as `Bool`, and sends `Action` on dismissal.
+    public func isPresented(onDismiss: @autoclosure @escaping () -> Action) -> Binding<Bool>
+        where State == Bool
+    {
+        self.binding(
+            onChange: { isPresented in
+                isPresented ? nil : onDismiss()
+            }
+        )
+    }
+}
+
+// MARK: - Direct (state-to-state) binding
+
+extension ViewStore
+{
+    /// Direct 2-way state binding for SwiftUI without sending user-defined action.
+    ///
+    /// - Warning:
+    ///   This binding will NOT run user-defined `Reducer`.
+    ///   Like Elm Architecture, if user wants to always run `Reducer` per UI state change,
+    ///   conversion from mutated state to `Action` is needed, e.g. ``binding(get:onChange:)``.
+    public var directBinding: Binding<State>
+    {
+        Binding<State>(
+            get: { self.state },
+            set: { newState, transaction in
+                _ = withTransaction(transaction) {
+                    // Send framework-defined `BindableAction.state`.
+                    self._send(.state(newState))
+                }
+            }
+        )
+    }
+}

--- a/Sources/ActomatonUI/SwiftUI/WithViewStore.swift
+++ b/Sources/ActomatonUI/SwiftUI/WithViewStore.swift
@@ -1,0 +1,69 @@
+import SwiftUI
+
+/// Observable ``ViewStore`` holder view that is created from unobservable ``Store``.
+///
+/// Example code:
+///
+/// ```swift
+/// struct ContentView: View {
+///     let store: Store<Action, State, Environment>
+///     ...
+///     var body: some View {
+///         WithViewStore(store) { viewStore in
+///             Text("Hello, \(viewStore.state.username)") // NOTE: Can shorten to `viewStore.username`.
+///         }
+///     }
+/// }
+/// ```
+public struct WithViewStore<Action, State, Content>: View
+    where Action: Sendable, State: Sendable, Content: View
+{
+    @ObservedObject
+    private var viewStore: ViewStore<Action, State>
+
+    private let content: @MainActor (ViewStore<Action, State>) -> Content
+
+    /// Initializer with `@ViewBuilder` and `areStatesEqual`.
+    public init<Environment>(
+        _ store: Store<Action, State, Environment>,
+        areStatesEqual: @escaping (State, State) -> Bool,
+        @ViewBuilder content: @escaping @MainActor (ViewStore<Action, State>) -> Content
+    ) where Environment: Sendable
+    {
+        self.viewStore = store.viewStore(areStatesEqual: areStatesEqual)
+        self.content = content
+    }
+
+    /// Initializer with `@ViewBuilder`.
+    public init<Environment>(
+        _ store: Store<Action, State, Environment>,
+        @ViewBuilder content: @escaping @MainActor (ViewStore<Action, State>) -> Content
+    ) where State: Equatable, Environment: Sendable
+    {
+        self.init(store, areStatesEqual: ==, content: content)
+    }
+
+    /// Initializer without `@ViewBuilder`, with `areStatesEqual`.
+    public init<Environment>(
+        _ store: Store<Action, State, Environment>,
+        areStatesEqual: @escaping (State, State) -> Bool,
+        _ content: @escaping @MainActor (ViewStore<Action, State>) -> Content
+    ) where State: Equatable, Environment: Sendable
+    {
+        self.init(store, areStatesEqual: areStatesEqual, content: content)
+    }
+
+    /// Initializer without `@ViewBuilder`.
+    public init<Environment>(
+        _ store: Store<Action, State, Environment>,
+        _ content: @escaping @MainActor (ViewStore<Action, State>) -> Content
+    ) where State: Equatable, Environment: Sendable
+    {
+        self.init(store, areStatesEqual: ==, content: content)
+    }
+
+    public var body: Content
+    {
+        self.content(self.viewStore)
+    }
+}

--- a/Sources/ActomatonUI/UIKit/HostingViewController.swift
+++ b/Sources/ActomatonUI/UIKit/HostingViewController.swift
@@ -1,0 +1,65 @@
+#if os(iOS) || os(tvOS)
+
+import UIKit
+import Combine
+import SwiftUI
+
+/// SwiftUI `View` & ``Store`` wrapper view controller that holds `UIHostingController`.
+@MainActor
+open class HostingViewController<Action, State, Environment, V: SwiftUI.View>: UIViewController
+    where Action: Sendable, State: Sendable, Environment: Sendable
+{
+    private let store: Any // `Store` or `RouteStore`.
+    private let rootView: AnyView
+
+    /// Initializer for ``Store`` as argument.
+    public init(
+        store: Store<Action, State, Environment>,
+        makeView: @escaping @MainActor (Store<Action, State, Environment>) -> V
+    )
+    {
+        self.store = store
+        self.rootView = AnyView(makeView(store))
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    /// Initializer for ``RouteStore`` as argument, with forgetting ``SendRouteEnvironment/sendRoute`` capability when `makeView`.
+    public init<Route>(
+        store routeStore: RouteStore<Action, State, Environment, Route>,
+        makeView: @escaping @MainActor (Store<Action, State, Environment>) -> V
+    )
+    {
+        self.store = routeStore
+
+        let substore = routeStore.noSendRoute
+        self.rootView = AnyView(makeView(substore))
+
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    public required init?(coder: NSCoder)
+    {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    open override func viewDidLoad()
+    {
+        super.viewDidLoad()
+
+        let hostVC = UIHostingController(rootView: rootView)
+        hostVC.view.translatesAutoresizingMaskIntoConstraints = false
+
+        self.addChild(hostVC)
+        self.view.addSubview(hostVC.view)
+        hostVC.didMove(toParent: self)
+
+        NSLayoutConstraint.activate([
+            self.view.leadingAnchor.constraint(equalTo: hostVC.view.leadingAnchor),
+            self.view.trailingAnchor.constraint(equalTo: hostVC.view.trailingAnchor),
+            self.view.topAnchor.constraint(equalTo: hostVC.view.topAnchor),
+            self.view.bottomAnchor.constraint(equalTo: hostVC.view.bottomAnchor)
+        ])
+    }
+}
+
+#endif

--- a/Sources/ActomatonUI/UIKit/RouteStore.swift
+++ b/Sources/ActomatonUI/UIKit/RouteStore.swift
@@ -1,0 +1,290 @@
+import Dispatch
+import Combine
+
+/// `Store` wrapper that also outputs `routes`, mainly used for UIKit's navigation handling.
+@MainActor
+public final class RouteStore<Action, State, Environment, Route>
+    : Store<Action, State, SendRouteEnvironment<Environment, Route>>
+    where Action: Sendable, State: Sendable, Environment: Sendable
+{
+    private let core: StoreCore<Action, State, SendRouteEnvironment<Environment, Route>>
+    private let _routes: PassthroughSubject<Route, Never>
+
+    /// Initializer with `environment`.
+    public init(
+        state: State,
+        reducer: Reducer<Action, State, SendRouteEnvironment<Environment, Route>>,
+        environment: Environment,
+        routeType: Route.Type = Route.self // for quick type-inference
+    )
+    {
+        let routes = PassthroughSubject<Route, Never>()
+        self._routes = routes
+
+        let sendRouteEnvironment = SendRouteEnvironment(
+            environment: environment,
+            sendRoute: { routes.send($0) }
+        )
+
+        let core = StoreCore<Action, State, SendRouteEnvironment<Environment, Route>>(
+            state: state,
+            reducer: reducer,
+            environment: sendRouteEnvironment
+        )
+        self.core = core
+
+        super.init(
+            state: core.state,
+            environment: sendRouteEnvironment,
+            send: { core.send($0, priority: $1, tracksFeedbacks: $2) }
+        )
+    }
+
+    /// Initializer without `environment`.
+    public convenience init(
+        state: State,
+        reducer: Reducer<Action, State, SendRouteEnvironment<Void, Route>>,
+        routeType: Route.Type = Route.self // for quick type-inference
+    ) where Environment == Void
+    {
+        self.init(
+            state: state,
+            reducer: reducer,
+            environment: ()
+        )
+    }
+
+    /// `Route` publisher.
+    public var routes: AnyPublisher<Route, Never>
+    {
+        self._routes
+            .receive(on: DispatchQueue.main)
+            .eraseToAnyPublisher()
+    }
+
+    /// Subscribes `routes` until `RouteStore`'s lifetime.
+    public func subscribeRoutes(_ routeHandler: @escaping (Route) -> Void)
+    {
+        self.routes
+            .sink(receiveValue: routeHandler)
+            .store(in: &self.core.cancellables)
+    }
+}
+
+// MARK: - noSendRoute
+
+extension RouteStore
+{
+    /// Maps `environment` from `SendRouteEnvironment<Environment, Route>` to `Environment`,
+    /// erasing `SendRouteEnvironment` and `Route`.
+    ///
+    /// ```swift
+    /// class MyViewController: UIViewController {
+    ///     let store: Store<Action, State, Environment>
+    ///     ...
+    /// }
+    ///
+    /// let routeStore = RouteStore(...)
+    ///
+    /// // NOTE:
+    /// // `vc` doesn't need to know about `RouteStore` and its route handling,
+    /// // so erase with `noSendRoute`.
+    /// let vc = MyViewController(store: routeStore.noSendRoute)
+    ///
+    /// vc.subscribeRoutes { route in ... }
+    /// ```
+    public var noSendRoute: Store<Action, State, Environment>
+    {
+        self.map(environment: \.environment)
+    }
+}
+
+// MARK: - SendRouteEnvironment
+
+/// Wrapper of original `environment` with attaching `sendRoute`.
+public struct SendRouteEnvironment<Environment, Route>: Sendable
+    where Environment: Sendable
+{
+    public var environment: Environment
+    public var sendRoute: @Sendable (Route) -> Void
+
+    public init(environment: Environment, sendRoute: @escaping @Sendable (Route) -> Void)
+    {
+        self.environment = environment
+        self.sendRoute = sendRoute
+    }
+
+    // MARK: sendRouteAsync
+
+    /// Sends `Route` with a callback that consumes `Value`.
+    ///
+    /// For example:
+    ///
+    /// ```swift
+    /// enum Route: Sendable {
+    ///     /// `Arg` is for setting up next screen, `Value` is generated from next screen.
+    ///     case showNextScreen(Arg, completion: (Value) -> Void)
+    /// }
+    ///
+    /// ...
+    ///
+    /// // Inside `RouteStore`'s Reducer:
+    /// Effect {
+    ///     /// Send `Route` and get `Value` from next screen.
+    ///     let value = await environment.sendRouteAsync { completion in
+    ///         return Route.showNextScreen(someArg, completion)
+    ///     }
+    ///     return Action.didFinishNextScreen(value)
+    /// }
+    /// ```
+    ///
+    /// - Parameter makeRoute:
+    ///   `Route` builder that takes `Value`-consumer (callback) as argument
+    ///   so that sender calls `sendRoute` and can also receive `Value` asynchronously via callback.
+    ///
+    /// - Returns: `Value` from routed destination asynchronously.
+    public func sendRouteAsync<Value>(
+        _ makeRoute: ((Value) -> Void) -> Route
+    ) async -> Value
+    {
+        await withCheckedContinuation { continuation in
+            let route = makeRoute(continuation.resume(returning:))
+            self.sendRoute(route)
+        }
+    }
+
+    /// Sends `Route` with a callback that consumes `Result<Value, Error>`.
+    ///
+    /// For example:
+    ///
+    /// ```swift
+    /// enum Route: Sendable {
+    ///     /// `Arg` is for setting up next screen, `Result<Value, Error>` is generated from next screen.
+    ///     case showNextScreen(Arg, completion: (Result<Value, Error>) -> Void)
+    /// }
+    ///
+    /// ...
+    ///
+    /// // Inside `RouteStore`'s Reducer:
+    /// Effect {
+    ///     do {
+    ///         /// Send `Route` and get `Value` from next screen.
+    ///         let value = try await environment.sendRouteAsync { completion in
+    ///             return Route.showNextScreen(someArg, completion)
+    ///         }
+    ///         return Action.didFinishNextScreen(value)
+    ///     } catch {
+    ///         return Action.didFailNextScreen(error)
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// - Parameter makeRoute:
+    ///   `Route` builder that takes `Value`-consumer (callback) as argument
+    ///   so that sender calls `sendRoute` and can also receive `Value` asynchronously via callback.
+    ///
+    /// - Returns: `Value` from routed destination asynchronously.
+    public func sendRouteAsync<Value, Error>(
+        _ makeRoute: ((Result<Value, Error>) -> Void) -> Route
+    ) async throws -> Value
+        where Error: Swift.Error
+    {
+        try await withCheckedThrowingContinuation { continuation in
+            let route = makeRoute(continuation.resume(with:))
+            self.sendRoute(route)
+        }
+    }
+
+    // MARK: sendRouteAsyncStream
+
+    /// Sends `Route` with `AsyncStream<Value>.Continuation` that can consume multiple `Value`s.
+    ///
+    /// For example:
+    ///
+    /// ```swift
+    /// enum Route: Sendable {
+    ///     /// `Arg` is for setting up next screen, `Event` is generated from next screen.
+    ///     case showNextScreen(Arg, AsyncStream<Event>.Continuation)
+    ///
+    ///     enum Event {
+    ///         case onNext(Int)
+    ///         case onCompleted
+    ///     }
+    /// }
+    ///
+    /// ...
+    ///
+    /// // Inside `RouteStore`'s Reducer:
+    /// Effect(sequence: {
+    ///     /// Send `Route` and get `AsyncStream` from next screen.
+    ///     let stream = environment.sendRouteAsyncStream { continuation in
+    ///         return Route.showNextScreen(someArg, continuation)
+    ///     }
+    ///
+    ///     return stream.map { event in
+    ///         switch event {
+    ///         case let .onNext(value):
+    ///             return Action._didReceiveValue(value)
+    ///         case let .onCompleted:
+    ///             return Action._didFinishReceivingValues
+    ///         }
+    ///     }
+    /// })
+    ///
+    /// ...
+    ///
+    /// store.subscribeRoutes { [weak vc] route in
+    ///     switch route {
+    ///     case let .showNextScreen(arg, continuation):
+    ///         let nextVC = NextViewController(arg: arg)
+    ///         nextVC.onData = { data in
+    ///             continuation.yield(.onNext(data))
+    ///         }
+    ///         nextVC.onFinished = { [weak vc] in
+    ///             vc?.dismiss(animated: true) {
+    ///                 continuation.yield(.onCompleted)
+    ///                 continuation.finish()
+    ///             }
+    ///         }
+    ///         vc.present(nextVC, animated: true)
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// - Parameter makeRoute:
+    ///   `Route` builder that takes `Value`-consumer (continuation as observer) as argument
+    ///   so that sender calls `sendRoute` and can also receive `Value`s asynchronously via stream.
+    ///
+    /// - Returns: `AsyncStream<Value>` from routed destination.
+    public func sendRouteAsyncStream<Value>(
+        _ makeRoute: @escaping (AsyncStream<Value>.Continuation) -> Route
+    ) -> AsyncStream<Value>
+    {
+        AsyncStream<Value> { continuation in
+            let route = makeRoute(continuation)
+            self.sendRoute(route)
+        }
+    }
+
+    /// Sends `Route` with `AsyncThrowingStream<Value, Error>.Continuation` that can consume multiple `Value`s.
+    ///
+    /// See ``sendRouteAsyncStream(_:)-8alh0`` doc-comment for more information.
+    ///
+    /// - Parameter makeRoute:
+    ///   `Route` builder that takes `Value`-consumer (continuation as observer) as argument
+    ///   so that sender calls `sendRoute` and can also receive `Value` asynchronously via stream.
+    ///
+    /// - Returns: `AsyncThrowingStream<Value, Error>` from routed destination.
+    public func sendRouteAsyncStream<Value>(
+        _ makeRoute: @escaping (AsyncThrowingStream<Value, Swift.Error>.Continuation) -> Route
+    ) -> AsyncThrowingStream<Value, Swift.Error>
+    {
+        // NOTE:
+        // Need to use `Swift.Error` and can't make it as generic error type
+        // due to `AsyncThrowingStream.init` having equality constraint.
+        AsyncThrowingStream<Value, Swift.Error> { continuation in
+            let route = makeRoute(continuation)
+            self.sendRoute(route)
+        }
+    }
+}

--- a/Sources/ActomatonUI/UncheckedSendable.swift
+++ b/Sources/ActomatonUI/UncheckedSendable.swift
@@ -1,0 +1,11 @@
+import Combine
+
+// TODO: Remove `@unchecked Sendable` when `Sendable` is supported by each module.
+
+extension PassthroughSubject: @unchecked Sendable {}
+
+extension Published.Publisher: @unchecked Sendable {}
+
+extension AnyPublisher: @unchecked Sendable {}
+
+extension AnyCancellable: @unchecked Sendable {}

--- a/Sources/ActomatonUI/_exported.swift
+++ b/Sources/ActomatonUI/_exported.swift
@@ -1,0 +1,1 @@
+@_exported import Actomaton


### PR DESCRIPTION
Successor of:
- #64 

Integration example:
- https://github.com/Actomaton/Actomaton-Gallery/pull/42

## Overview

This PR adds a new **`ActomatonUI` module** that inherits the core functionality from `ActomatonStore` which also allows SwiftUI-rendering optimization using `ViewStore`.

The original idea of `ViewStore` is from [swift-composable-architecture](https://github.com/pointfreeco/swift-composable-architecture) with compatible API names (e.g. `ViewStore`) and slight internal differences.

### Background

Current [Actomaton-Gallery](https://github.com/Actomaton/Actomaton-Gallery/tree/5898d7b96c1d96eeaccce85d615ce83a9aa271dd/Examples/SwiftUI-Gallery) demo app uses `ActomatonStore` as a SwiftUI-bridge of Actomaton.

It has a very simple (and naive) rendering structure: i.e. putting `@StateObject` in a root `SwiftUI.View` and let child views only own its (sub) `Binding<State>`s:

1. `Store` (`ObservableObject`) lives at topmost view, and will be observed by `@StateObject`
2. `Store.Proxy` lives in each subviews, and is capable of providing `Binding<State>`

so that only a single observation point (`@StateObject var store: Store`) was necessary at the topmost view.

This approach is a very traditional Elm-like rendering approach that always does `let wholeView = render(wholeState)` (not `let partialView = render(partialState)` and manually summing up), and let rendering system take care of the complicated "partial" diffing part.

As of iOS 15, this approach worked fairly well including high-CPU-usage SwiftUI screens, e.g. [LineCollisionExample](https://github.com/Actomaton/Actomaton-Gallery/blob/5898d7b96c1d96eeaccce85d615ce83a9aa271dd/Sources/Physics/ExampleList/Examples/LineCollisionExample.swift) that runs at 60 frames per seconds + a lot of user-dragging events + physics calculation, to make views updated per every tick.
This means, **SwiftUI's diff-rendering is actually already quite performant** although the `ActomatonStore` strategy always re-renders from the topmost view.

However, this naive approach had some other drawbacks too:

1. Explicit animation (`withAnimation`) didn't work as expected in the screens where `NavigationView` wraps
2. A new iOS 16 `NavigationStack` causes the re-rendering not working correctly

Yes, **The SwiftUI Navigation™️ issue!**

While there had been some workarounds applied to `NavigationView` in every iOS releasing year which barely worked until iOS 15, but now, new iOS 16 (as of Beta 3) `NavigationStack` will break it in even more hopeless way that **single-`@StateObject`-at-top (and providing child stores to subviews) approach is unlikely become possible.**

Since the basic SwiftUI design and (implicit) guideline is to "use ViewModel to wrap state per screen (OOP-style)", unfortunately, Elm-style also needs to somehow adopt this rule so that safe and faster rendering can become possible.

Luckily, the refactoring could be easily done by just swapping the above strategy into:

1. `Store` (non-`ObservableObject`) lives at topmost view, and narrows down as sub-stores to be passed to its child views
2. `ViewStore` (`ObservableObject`) lives in each subviews as a partial SwiftUI states to be observed by `@ObservabedObject`, and is capable of providing `Binding<State>`

which literally has the **same mechanism as [swift-composable-architecture](https://github.com/pointfreeco/swift-composable-architecture)** which already has solved in the very beginning.

Thus, this PR now applies its basic strategy with following the same naming, including `WithViewStore` as an efficient partial view re-rendering component.

The cons of `ViewStore` approach is that **`WithViewStore` will now require in many places throughout the app** (rather than just placing single `@StateObject` at root), which often **requires state-extracting optimization** to narrow down `Store`'s scope to only hold the very necessary subsets for minimal changes (which is actually quite difficult process whenever one considers about creating the container view that contains some child view, and let only child rendering run optimally).

As mentioned above, this cumbersome issue is due to SwiftUI's ViewModel-first design and Navigation issue that easily breaks per every iOS release.
As `ViewStore` is a translation from Elm (sub-)store into ViewModel (per each screen) which is a safe and decent approach, I decided to take this pill for safer future implementation without bothering SwiftUI changes too much.