### PR TITLE
[UI] Add `StoreConfiguration` for Store's better `LogFormat` support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
             targets: ["Actomaton", "ActomatonDebugging"]),
         .library(
             name: "ActomatonUI",
-            targets: ["ActomatonUI", "ActomatonDebugging"]),
+            targets: ["ActomatonUI"]),
         .library(
             name: "ActomatonStore",
             targets: ["ActomatonStore", "ActomatonDebugging"])
@@ -46,7 +46,7 @@ let package = Package(
         .target(
             name: "ActomatonUI",
             dependencies: [
-                "Actomaton"
+                "Actomaton", "ActomatonDebugging"
             ],
             swiftSettings: [
                 .unsafeFlags([

--- a/Sources/ActomatonUI/Store/Internal/BindableAction.swift
+++ b/Sources/ActomatonUI/Store/Internal/BindableAction.swift
@@ -23,6 +23,9 @@ internal enum BindableAction<Action, State>: Sendable, CustomDumpRepresentable
         case let .action(action):
             return action
         case .state:
+            // NOTE:
+            // Don't print verbose whole `state` here,
+            // since "state diff" printing is usually sufficient.
             return "BindableAction.state"
         }
     }

--- a/Sources/ActomatonUI/Store/Internal/BindableAction.swift
+++ b/Sources/ActomatonUI/Store/Internal/BindableAction.swift
@@ -1,5 +1,7 @@
+import CustomDump
+
 /// `action` as indirect messaging, or `state` that can directly replace `actomaton.state` via SwiftUI 2-way binding.
-internal enum BindableAction<Action, State>: Sendable
+internal enum BindableAction<Action, State>: Sendable, CustomDumpRepresentable
     where Action: Sendable, State: Sendable
 {
     case action(Action)
@@ -12,6 +14,16 @@ internal enum BindableAction<Action, State>: Sendable
             return .action(f(action))
         case let .state(state):
             return .state(state)
+        }
+    }
+
+    var customDumpValue: Any
+    {
+        switch self {
+        case let .action(action):
+            return action
+        case .state:
+            return "BindableAction.state"
         }
     }
 }

--- a/Sources/ActomatonUI/Store/Internal/StoreCore.swift
+++ b/Sources/ActomatonUI/Store/Internal/StoreCore.swift
@@ -7,7 +7,6 @@ internal final class StoreCore<Action, State, Environment>
     where Action: Sendable, State: Sendable, Environment: Sendable
 {
     private let actomaton: MainActomaton<BindableAction<Action, State>, State>
-    private let reducer: Reducer<Action, State, Environment>
 
     private let _state: CurrentValueSubject<State, Never>
 
@@ -19,18 +18,17 @@ internal final class StoreCore<Action, State, Environment>
     internal init(
         state initialState: State,
         reducer: Reducer<Action, State, Environment>,
-        environment: Environment
+        environment: Environment,
+        configuration: StoreConfiguration
     )
     {
         self._state = CurrentValueSubject(initialState)
-        self.reducer = reducer
         self.environment = environment
 
         self.actomaton = MainActomaton(
             state: initialState,
-            reducer: lift(reducer: Reducer { action, state, environment in
-                reducer.run(action, &state, environment)
-            }),
+            reducer: lift(reducer: reducer)
+                .log(format: configuration.logFormat),
             environment: environment
         )
 

--- a/Sources/ActomatonUI/Store/Store.swift
+++ b/Sources/ActomatonUI/Store/Store.swift
@@ -61,13 +61,15 @@ public class Store<Action, State, Environment>
     public convenience init(
         state initialState: State,
         reducer: Reducer<Action, State, Environment>,
-        environment: Environment
+        environment: Environment,
+        configuration: StoreConfiguration = .init()
     )
     {
         let core = StoreCore<Action, State, Environment>(
             state: initialState,
             reducer: reducer,
-            environment: environment
+            environment: environment,
+            configuration: configuration
         )
 
         self.init(
@@ -80,13 +82,15 @@ public class Store<Action, State, Environment>
     /// Initializer without `environment`.
     public convenience init(
         state initialState: State,
-        reducer: Reducer<Action, State, Void>
+        reducer: Reducer<Action, State, Void>,
+        configuration: StoreConfiguration = .init()
     ) where Environment == Void
     {
         self.init(
             state: initialState,
             reducer: reducer,
-            environment: ()
+            environment: (),
+            configuration: configuration
         )
     }
 

--- a/Sources/ActomatonUI/Store/StoreConfiguration.swift
+++ b/Sources/ActomatonUI/Store/StoreConfiguration.swift
@@ -1,0 +1,15 @@
+import ActomatonDebugging
+
+/// ``Store`` configuration for customization, e.g. `logFormat`.
+public struct StoreConfiguration
+{
+    /// Reducer debug-logging format that also detects direct-state-binding changes.
+    let logFormat: LogFormat?
+
+    /// - Parameter logFormat:
+    ///   Debug-logging format for ``Store``, including detection of direct-state-binding changes. Default value is `nil` (no logging).
+    public init(logFormat: LogFormat? = nil)
+    {
+        self.logFormat = logFormat
+    }
+}

--- a/Sources/ActomatonUI/UIKit/RouteStore.swift
+++ b/Sources/ActomatonUI/UIKit/RouteStore.swift
@@ -15,6 +15,7 @@ public final class RouteStore<Action, State, Environment, Route>
         state: State,
         reducer: Reducer<Action, State, SendRouteEnvironment<Environment, Route>>,
         environment: Environment,
+        configuration: StoreConfiguration = .init(),
         routeType: Route.Type = Route.self // for quick type-inference
     )
     {
@@ -29,7 +30,8 @@ public final class RouteStore<Action, State, Environment, Route>
         let core = StoreCore<Action, State, SendRouteEnvironment<Environment, Route>>(
             state: state,
             reducer: reducer,
-            environment: sendRouteEnvironment
+            environment: sendRouteEnvironment,
+            configuration: configuration
         )
         self.core = core
 

--- a/Sources/ActomatonUI/_exported.swift
+++ b/Sources/ActomatonUI/_exported.swift
@@ -1,1 +1,2 @@
 @_exported import Actomaton
+@_exported import ActomatonDebugging


### PR DESCRIPTION
Continued from:
- #69 

Related:
- #66 

This PR adds `StoreConfiguration` that allows better Action & State debug-logging including the observation of direct-state-binding changes, which wasn't possible before.

By introducing this PR, `ActomatonUI` will now depend on `ActomatonDebugging`.