### PR TITLE
[Test] Add ActomatonUITests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -93,6 +93,16 @@ let package = Package(
             ]
         ),
         .testTarget(
+            name: "ActomatonUITests",
+            dependencies: ["ActomatonUI", "TestFixtures"],
+            swiftSettings: [
+                .unsafeFlags([
+                    "-Xfrontend", "-warn-concurrency",
+                    "-Xfrontend", "-enable-actor-data-race-checks",
+                ])
+            ]
+        ),
+        .testTarget(
             name: "ReadMeTests",
             dependencies: ["ActomatonStore", "ActomatonDebugging"],
             swiftSettings: [

--- a/Tests/ActomatonUITests/DeinitTests.swift
+++ b/Tests/ActomatonUITests/DeinitTests.swift
@@ -1,0 +1,94 @@
+import XCTest
+@testable import ActomatonUI
+
+/// Tests for `Actomaton.deinit` to run successfully with cancelling running tasks.
+@MainActor
+final class DeinitTests: XCTestCase
+{
+    func test_deinit() async throws
+    {
+        let resultsCollector = ResultsCollector<String>()
+
+        var actomaton: Store? = Store<Action, State, Environment>(
+            state: State(),
+            reducer: Reducer { [resultsCollector] action, state, _ in
+                switch action {
+                case .run:
+                    return Effect { [resultsCollector] in
+                        return try await tick(5) {
+                            await resultsCollector.append("Effect succeeded")
+                            return nil
+                        } ifCancelled: {
+                            Debug.print("Effect cancelled")
+                            await resultsCollector.append("Effect cancelled")
+                            return nil
+                        }
+                    }
+                }
+            },
+            environment: Environment(resultsCollector: resultsCollector)
+        )
+
+        weak var weakActomaton = actomaton
+
+        let task = actomaton?.send(.run)
+        try await tick(1)
+
+        // Deinit `actomaton`.
+        actomaton = nil
+        XCTAssertNil(weakActomaton, "`weakActomaton` should also become `nil`.")
+
+        // Wait until deinit fully completes.
+        try? await task?.value
+
+        // Check results.
+        //
+        // NOTE:
+        // Arrival timing of 2 results are almost simultaneous thus isn't guaranteed in order,
+        // so will use `Set` here.
+        let results = await resultsCollector.results
+        XCTAssertEqual(
+            Set(results), ["Effect cancelled", "DeinitChecker deinit"],
+            "Running effect should be cancelled, and `DeinitChecker` should deinit."
+        )
+    }
+}
+
+// MARK: - Private
+
+private enum Action
+{
+    case run
+}
+
+private struct State
+{
+    init() {}
+}
+
+private struct Environment: Sendable
+{
+    let deinitChecker: DeinitChecker
+
+    init(resultsCollector: ResultsCollector<String>)
+    {
+        self.deinitChecker = DeinitChecker(resultsCollector: resultsCollector)
+    }
+}
+
+private actor DeinitChecker
+{
+    let resultsCollector: ResultsCollector<String>
+
+    init(resultsCollector: ResultsCollector<String>)
+    {
+        self.resultsCollector = resultsCollector
+    }
+
+    deinit
+    {
+        Task { [resultsCollector] in
+            await resultsCollector.append("DeinitChecker deinit")
+        }
+    }
+}

--- a/Tests/ActomatonUITests/_exported.swift
+++ b/Tests/ActomatonUITests/_exported.swift
@@ -1,0 +1,1 @@
+@_exported import TestFixtures


### PR DESCRIPTION
Related:
- https://github.com/Actomaton/Actomaton/pull/62
- #66 

This PR adds `ActomatonUITests` which is copied from original `ActomatonStoreTests` introduced in https://github.com/Actomaton/Actomaton/pull/62 .

NOTE: The codebase is exactly the same as before.