### PR TITLE
Fix package.swift for use with SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,10 @@ let package = Package(
             targets: ["ActomatonUI"]),
         .library(
             name: "ActomatonStore",
-            targets: ["ActomatonStore", "ActomatonDebugging"])
+            targets: ["ActomatonStore", "ActomatonDebugging"]),
+        .library(
+            name: "ActomatonDebugging",
+            targets: ["ActomatonDebugging"])
     ],
     dependencies: [
         .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "0.7.0"),


### PR DESCRIPTION
ActomatonをSPMで導入した時に、ActomaotnDebuggingを使えるようPackage.swiftでlibraryとして公開するように修正
ローカル環境で他のパッケージから読み込んで動くことも確認済み