### PR TITLE
Use Swift 5.9 custom executor

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.9
 
 import PackageDescription
 
@@ -26,8 +26,7 @@ let package = Package(
             dependencies: [.product(name: "CasePaths", package: "swift-case-paths")],
             swiftSettings: [
                 .unsafeFlags([
-                    "-Xfrontend", "-warn-concurrency",
-                    "-Xfrontend", "-enable-actor-data-race-checks",
+                    "-Xfrontend", "-strict-concurrency=complete",
                 ])
             ]
         ),
@@ -38,8 +37,7 @@ let package = Package(
             ],
             swiftSettings: [
                 .unsafeFlags([
-                    "-Xfrontend", "-warn-concurrency",
-                    "-Xfrontend", "-enable-actor-data-race-checks",
+                    "-Xfrontend", "-strict-concurrency=complete",
                 ])
             ]
         ),
@@ -50,8 +48,7 @@ let package = Package(
             ],
             swiftSettings: [
                 .unsafeFlags([
-                    "-Xfrontend", "-warn-concurrency",
-                    "-Xfrontend", "-enable-actor-data-race-checks",
+                    "-Xfrontend", "-strict-concurrency=complete",
                 ])
             ]
         ),
@@ -67,8 +64,7 @@ let package = Package(
             path: "./Tests/TestFixtures",
             swiftSettings: [
                 .unsafeFlags([
-                    "-Xfrontend", "-warn-concurrency",
-                    "-Xfrontend", "-enable-actor-data-race-checks",
+                    "-Xfrontend", "-strict-concurrency=complete",
                 ])
             ]
         ),
@@ -77,8 +73,7 @@ let package = Package(
             dependencies: ["Actomaton", "TestFixtures"],
             swiftSettings: [
                 .unsafeFlags([
-                    "-Xfrontend", "-warn-concurrency",
-                    "-Xfrontend", "-enable-actor-data-race-checks",
+                    "-Xfrontend", "-strict-concurrency=complete",
                 ])
             ]
         ),
@@ -87,8 +82,7 @@ let package = Package(
             dependencies: ["ActomatonStore", "TestFixtures"],
             swiftSettings: [
                 .unsafeFlags([
-                    "-Xfrontend", "-warn-concurrency",
-                    "-Xfrontend", "-enable-actor-data-race-checks",
+                    "-Xfrontend", "-strict-concurrency=complete",
                 ])
             ]
         ),
@@ -97,8 +91,7 @@ let package = Package(
             dependencies: ["ActomatonUI", "TestFixtures"],
             swiftSettings: [
                 .unsafeFlags([
-                    "-Xfrontend", "-warn-concurrency",
-                    "-Xfrontend", "-enable-actor-data-race-checks",
+                    "-Xfrontend", "-strict-concurrency=complete",
                 ])
             ]
         ),
@@ -107,8 +100,7 @@ let package = Package(
             dependencies: ["ActomatonStore", "ActomatonDebugging"],
             swiftSettings: [
                 .unsafeFlags([
-                    "-Xfrontend", "-warn-concurrency",
-                    "-Xfrontend", "-enable-actor-data-race-checks",
+                    "-Xfrontend", "-strict-concurrency=complete",
                 ])
             ]
         )


### PR DESCRIPTION
This PR refactors `MainActomaton` by changing it from `public final class` to `package protocol` (thus this PR is a **breaking change**), and move previous implementation into `package class MainActomaton1` (ver 1), then adding a new `MainActomaton2` (ver 2).

`MainActomaton2` is a full replacement of `MainActomaton1` using [Swift 5.9's Custom Executor](https://github.com/apple/swift-evolution/blob/main/proposals/0392-custom-actor-executors.md), which is available from macOS 14.0 / iOS 17.0.
In Swift 5.9, `MainActomaton2` is now capable of inheriting `actor Actomaton`'s existing code without code duplication.
Same as previous ver 1, ver 2 also always runs on top of `MainActor`'s executor by using `Actor.assumeIsolated` method.

`MainActomaton2` is package-internally used in `ActomatonUI.Store(Core)` , so users won't usually notice the difference.
