### PR TITLE
Include `ActomatonDebugging` as `ActomatonUI` library target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,13 +11,10 @@ let package = Package(
             targets: ["Actomaton", "ActomatonDebugging"]),
         .library(
             name: "ActomatonUI",
-            targets: ["ActomatonUI"]),
+            targets: ["ActomatonUI", "ActomatonDebugging"]),
         .library(
             name: "ActomatonStore",
             targets: ["ActomatonStore", "ActomatonDebugging"]),
-        .library(
-            name: "ActomatonDebugging",
-            targets: ["ActomatonDebugging"])
     ],
     dependencies: [
         .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "0.7.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,10 @@ let package = Package(
             targets: ["ActomatonUI"]),
         .library(
             name: "ActomatonStore",
-            targets: ["ActomatonStore", "ActomatonDebugging"])
+            targets: ["ActomatonStore", "ActomatonDebugging"]),
+        .library(
+            name: "ActomatonDebugging",
+            targets: ["ActomatonDebugging"])
     ],
     dependencies: [
         .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "0.7.0"),


### PR DESCRIPTION
Retry of:
- #77

This PR updates `Package.swift` by also adding `ActomatonDebugging` as `ActomatonUI` library target.
